### PR TITLE
[FEAT/REFACTOR] 리뷰 제거 시 comment 댓글 제거 기능 추가

### DIFF
--- a/src/main/java/com/review/storereview/common/ImageClearScheduler.java
+++ b/src/main/java/com/review/storereview/common/ImageClearScheduler.java
@@ -26,6 +26,6 @@ public class ImageClearScheduler {
         // TODO: 2022-06-27 로그를 남겨둬야할 것 같다.
         log.info("ImageClearScheduler.clearDeletedImage() 실행 (" + now + ")");
 
-        imageService.clearUnusedImagesInDBAndS3for3weeks(now.toDate());
+        imageService.clearUnusedImagesInDBAndS3for3weeksByScheduler(now.toDate());
     }
 }

--- a/src/main/java/com/review/storereview/controller/cms/CommentApiController.java
+++ b/src/main/java/com/review/storereview/controller/cms/CommentApiController.java
@@ -236,7 +236,7 @@ public class CommentApiController {
 
             //SUID 유효성 체크.
             if (comment.getUser().getSuid().equals(userDetails.getSuid())) {
-                comment.setisDelete(1);
+                comment.setIsDelete(1);
                 // 코멘트 삭제 서비스 처리
                 Comment deleteComment = commentService.save(comment);
 

--- a/src/main/java/com/review/storereview/dao/cms/Comment.java
+++ b/src/main/java/com/review/storereview/dao/cms/Comment.java
@@ -37,9 +37,9 @@ public class Comment extends BaseTimeEntity {
     private Integer isDelete;
 
 
-    public void setisDelete(Integer isdelete)
+    public void setIsDelete(Integer isDelete)
     {
-        isDelete = isdelete;
+        this.isDelete = isDelete;
     }
 
     @Builder

--- a/src/main/java/com/review/storereview/repository/cms/BaseCommentRepository.java
+++ b/src/main/java/com/review/storereview/repository/cms/BaseCommentRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 /**
  * Class       : BaseCommentRepository
  * Author      : 조 준 희
@@ -29,6 +31,7 @@ public interface BaseCommentRepository extends JpaRepository<Comment, Long> {
 //                            "  AND CO.SAID = UI.SAID    " +
 //                            "WHERE CO.REVIEW = ?1 ", nativeQuery = true )
     Page<Comment> findAllByReviewIdAndIsDelete(Long reviewId, Integer IsDelete, Pageable pageRequest);
+    List<Comment> findAllByReviewIdAndIsDelete(Long reviewId, Integer IsDelete);
     Comment findByCommentId(Long commentID);
 
     @Query(value= "SELECT COUNT(COMMENT.COMMENT_ID) from COMMENT where COMMENT.REVIEW_ID =?", nativeQuery = true)


### PR DESCRIPTION
## What is this PR? :mag:
** [FEAT/REFACTOR] 리뷰 제거 시 comment 댓글 제거 기능 추가

## Changes :memo:
`ImageService.java` 
- [REFACTOR] 이미지 데이터를 지우는게 아닌, reviewId를 `null`로 세팅하도록 수정
  - 지우는 작업은 스케줄링에 의해 진행 
- [STYLE] 메서드명과 변수명 수정

`ReviewServiceImpl.java`
- [FEAT] 리뷰 글 삭제될 때 코멘트 데이터 또한 `isDelete` 칼럼을 1로 세팅
  - [FEAT] `BaseCommentRepository.java` : `findAllByReviewIdAndIsDelete` 메서드 추가
- [STYLE] 메서드명과 변수명 수정

[REFACTOR]
- `Comment.java`, `CommentApiController.java` : 변수명 camel case로 수정
- `ImageClearScheduler.java`, `Image.java` : 메서드명 수정